### PR TITLE
Enable logging in embear library

### DIFF
--- a/build/BUILD.logger
+++ b/build/BUILD.logger
@@ -3,5 +3,6 @@ licenses(["notice"])  # MIT
 cc_library(name="logger",
            srcs=["src/logger.c"],
            hdrs=["include/logger.h"],
+           copts=["-DLOGGER_ENABLE"],
            strip_include_prefix = "include",
            visibility=["//visibility:public"])


### PR DESCRIPTION
As stated on https://github.com/embear/logger

> Logger needs to be enabled using the global define LOGGER_ENABLE when compiling the sources. Otherwise all functions will be excluded from compilation.

The current BUILD.logger is producing an empty library.