### PR TITLE
infra: add tests for all libraries in rules_iota

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -143,3 +143,27 @@ cc_test(
     srcs = ["libuv_test.c"],
     deps = ["@libuv"],
 )
+
+cc_test(
+    name = "sqlite3_test",
+    srcs = ["sqlite3_test.c"],
+    deps = ["@sqlite3"],
+)
+
+cc_test(
+    name = "cppzmq_test",
+    srcs = ["cppzmq_test.cc"],
+    deps = ["@cppzmq"],
+)
+
+cc_test(
+    name = "optional_lite_test",
+    srcs = ["optional_lite_test.cc"],
+    deps = ["@optional_lite"],
+)
+
+cc_test(
+    name = "rxcpp_test",
+    srcs = ["rxcpp_test.cc"],
+    deps = ["@rxcpp"],
+)

--- a/tests/cppzmq_test.cc
+++ b/tests/cppzmq_test.cc
@@ -1,0 +1,7 @@
+#include <zmq.hpp>
+
+int main(int argc, char **argv)
+{
+    zmq::context_t context;
+    return 0;
+}

--- a/tests/optional_lite_test.cc
+++ b/tests/optional_lite_test.cc
@@ -1,0 +1,25 @@
+#include "nonstd/optional.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+using nonstd::optional;
+using nonstd::nullopt;
+
+optional<int> to_int( char const * const text )
+{
+    char * pos = NULL;
+    const int value = static_cast<int>( strtol( text, &pos, 0 ) );
+
+    return pos == text ? nullopt : optional<int>( value );
+}
+
+int main( int argc, char * argv[] )
+{
+    const char * text = argc > 1 ? argv[1] : "42";
+
+    optional<int> oi = to_int( text );
+
+    if ( oi ) std::cout << "'" << text << "' is " << *oi << std::endl;
+    else      std::cout << "'" << text << "' isn't a number" << std::endl;
+}

--- a/tests/optional_lite_test.cc
+++ b/tests/optional_lite_test.cc
@@ -22,4 +22,5 @@ int main( int argc, char * argv[] )
 
     if ( oi ) std::cout << "'" << text << "' is " << *oi << std::endl;
     else      std::cout << "'" << text << "' isn't a number" << std::endl;
+    return 0;
 }

--- a/tests/rxcpp_test.cc
+++ b/tests/rxcpp_test.cc
@@ -1,0 +1,42 @@
+#include "rx.hpp"
+// create alias' to simplify code
+// these are owned by the user so that
+// conflicts can be managed by the user.
+namespace rx = rxcpp;
+namespace rxu = rxcpp::util;
+
+#include <string>
+
+// At this time, RxCpp will fail to compile if the contents
+// of the std namespace are merged into the global namespace
+// DO NOT USE: 'using namespace std;'
+
+#ifdef UNICODE
+int wmain()
+#else
+int main()
+#endif
+{
+    auto get_names = []() { return rx::observable<>::from<std::string>(
+                                "Matthew",
+                                "Aaron"); };
+
+    std::cout << "===== println stream of std::string =====" << std::endl;
+    auto hello_str = [&]() { return get_names().map([](std::string n) {
+                                                   return "Hello, " + n + "!";
+                                               })
+                                 .as_dynamic(); };
+
+    hello_str().subscribe(rxu::println(std::cout));
+
+    std::cout << "===== println stream of std::tuple =====" << std::endl;
+    auto hello_tpl = [&]() { return get_names().map([](std::string n) {
+                                                   return std::make_tuple("Hello, ", n, "! (", n.size(), ")");
+                                               })
+                                 .as_dynamic(); };
+
+    hello_tpl().subscribe(rxu::println(std::cout));
+
+    hello_tpl().subscribe(rxu::print_followed_by(std::cout, " and "), rxu::endline(std::cout));
+    return 0;
+}

--- a/tests/sqlite3_test.c
+++ b/tests/sqlite3_test.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sqlite3.h>
+
+int main(int argc, char* argv[])
+{
+   sqlite3 *db;
+   int rc;
+
+   rc = sqlite3_open("test.db", &db);
+
+   if( rc ){
+      fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
+      exit(0);
+   }else{
+      fprintf(stderr, "Opened database successfully\n");
+   }
+   sqlite3_close(db);
+}

--- a/tests/sqlite3_test.c
+++ b/tests/sqlite3_test.c
@@ -16,4 +16,5 @@ int main(int argc, char* argv[])
       fprintf(stderr, "Opened database successfully\n");
    }
    sqlite3_close(db);
+   return 0;
 }


### PR DESCRIPTION
Fixes [entangled #1319](https://github.com/iotaledger/entangled/issues/1319)

no use:
1) not used in entangled by grepping the name
    bzip2, civetweb, libzmq, rb_tree

2) have rules_iota/build/BUILD.*, but not defined in internal/repositories.bzl
    lzma, nanomsg, zlib, fmt
   
added test cases:
    cppzmq, optional_lite, rxcpp, sqlite3