### PR TITLE
fix keccak_sponge_1600 srcs

### DIFF
--- a/build/BUILD.keccak
+++ b/build/BUILD.keccak
@@ -51,6 +51,8 @@ cc_library(
     srcs = [
         "lib/high/Keccak/KeccakSpongeWidth1600.c",
         "lib/high/Keccak/KeccakSpongeWidth1600.h",
+        "lib/high/Keccak/KeccakSponge.inc",
+        "lib/high/Keccak/KeccakSponge-common.h",
     ],
     hdrs = [
         "lib/high/Keccak/KeccakSpongeWidth1600.h",


### PR DESCRIPTION
I am porting cIRI to YoctoProject/OpenEmbedded ([meta-iota](https://github.com/bernardoaraujor/meta-iota/blob/ciri-dev/recipes-iota/ciri/ciri_0.1.0.bb)):
Recently I faced the following error:

```
ERROR: /home/bernardo/dev/yocto/poky/build/tmp/work/armv7vet2hf-neon-poky-linux-gnueabi/ciri/0.1.0-r0/bazel/output_base/external/keccak/BUILD.bazel:49:1: undeclared inclusion(s) in rule '@keccak//:keccak_sponge_1600':
| this rule is missing dependency declarations for the following files included by 'external/keccak/lib/high/Keccak/KeccakSpongeWidth1600.c':
|   'external/keccak/lib/high/Keccak/KeccakSponge-common.h'
|   'external/keccak/lib/high/Keccak/KeccakSponge.inc'
| <command-line>: warning: "_FORTIFY_SOURCE" redefined
| <command-line>: note: this is the location of the previous definition
| Target //ciri:ciri failed to build
| INFO: Elapsed time: 11.521s, Critical Path: 0.84s
| INFO: 41 processes: 41 local.
| FAILED: Build did NOT complete successfully
| FAILED: Build did NOT complete successfully
| WARNING: exit code 1 from a shell command.
```

Adding `KeccakSponge-common.h` and `KeccakSponge.inc` to the `srcs` field of the `keccak_sponge_1600` target fixed the problem.
I hope this is useful for other projects that use `@keccak` of `rules_iota`.